### PR TITLE
CLOUD-410 ktlo: switch dependabot to monthly with staggered time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+      time: "14:00"
+      timezone: "Europe/Berlin"
     cooldown:
       default-days: 3


### PR DESCRIPTION
> **Action required from the owning team:** please review and merge this PR. It is a follow-up to a previously-merged [CLOUD-410](https://jimplan.atlassian.net/browse/CLOUD-410) PR; the Cloud team is not merging on your behalf.

## Summary

The earlier CLOUD-410 PR added `.github/dependabot.yml` with `interval: "weekly"`, which defaults to **Monday 05:00 UTC**. With ~100+ repos onto the same Monday cron, that risks a weekly dependabot-PR spike across the org.

This PR switches that schedule to:

- `interval: "monthly"` (matches the `/pin-gh-actions` skill prescription and the most common pattern in Jimdo repos)
- `time: "HH:00"` with `HH` randomly chosen between **09 and 15** (one fixed hour per repo)
- `timezone: "Europe/Berlin"` so the time lands in working hours, not the middle of the night

Net effect: this repo's dependabot will scan on the 1st of each month at its assigned hour Berlin time. Across the org the scans are spread across 09:00–15:00 so any resulting PRs trickle in over the working day rather than landing in a single 05:00 burst.

## Test plan

- [ ] CI passes
- [ ] No unintended changes outside `.github/dependabot.yml`


[CLOUD-410]: https://jimplan.atlassian.net/browse/CLOUD-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ